### PR TITLE
Version 0.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Thumbs.db
 .vscode/
 *.swp
 tmp/
+.code*
 
 # -----------------
 # Benchmarks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## [0.4.2] - 2026-04-20
+
+### Added
+- Added a first-class `--api-key` CLI option for `scan` and `agent`, backed by `SNAPFS_API_KEY`.
+- Added a small `.env` example to the README to show the common gateway, API key, agent id, and scan root configuration.
+
+### Changed
+- Changed CLI gateway handling so users must provide `--gateway` or `SNAPFS_GATEWAY` explicitly instead of inheriting the localhost development default in command usage.
+- Simplified gateway help text so user-facing CLI help no longer advertises the local development gateway default.
+- Marked `--token` as an advanced auth path while keeping it available for explicit bearer-token workflows.
+
+---
+
 ## [0.4.1] - 2026-03-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ To enable optional `xxh64` hashing support:
 pip install -e .[xxhash]
 ```
 
+## Example `.env`
+
+For agent or CLI-based scans, a minimal environment file often looks like:
+
+```dotenv
+SNAPFS_GATEWAY=https://example.snapfs.com
+SNAPFS_API_KEY=YOUR_API_KEY
+SNAPFS_AGENT_ID=scanner-01
+SNAPFS_SCAN_ROOT=/mnt/data
+```
+
+You can export these values in your shell, load them from a local `.env`, or translate them into your service manager configuration.
+
 ## Install The Systemd Agent
 
 For Linux hosts that should run the SnapFS scanner agent as a service:

--- a/lib/snapfs/__init__.py
+++ b/lib/snapfs/__init__.py
@@ -16,7 +16,7 @@
 
 __author__ = "Ryan Galloway <ryan@rsg.io>"
 __prog__ = "snapfs"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __doc__ = """
 Intelligent filesystem indexing and deduplication for massive data sets
 """

--- a/lib/snapfs/cli.py
+++ b/lib/snapfs/cli.py
@@ -30,7 +30,7 @@ from snapfs.config import settings
 F = TypeVar("F", bound=Callable[..., object])
 
 
-def _require_gateway(gateway_url: str) -> None:
+def _require_gateway(gateway_url: Optional[str]) -> None:
     if not gateway_url:
         raise click.ClickException("Missing --gateway (or SNAPFS_GATEWAY).")
 
@@ -230,7 +230,7 @@ def scan(
     workers: int,
     hash_chunk_size: int,
     verbose: int,
-    gateway_url: str,
+    gateway_url: Optional[str],
     api_key: Optional[str],
     token: Optional[str],
 ) -> None:
@@ -244,7 +244,7 @@ def scan(
     """
     _require_gateway(gateway_url)
 
-    if api_key is not None:
+    if token is None and api_key is not None:
         settings.api_key = api_key
     client = SnapFS(gateway_url=gateway_url, token=token)
     _auto_auth_scanner_client(client, token)
@@ -325,7 +325,7 @@ def agent(
     workers: int,
     hash_chunk_size: int,
     verbose: int,
-    gateway_url: str,
+    gateway_url: Optional[str],
     api_key: Optional[str],
     token: Optional[str],
 ) -> None:
@@ -338,7 +338,7 @@ def agent(
     """
     _require_gateway(gateway_url)
 
-    if api_key is not None:
+    if token is None and api_key is not None:
         settings.api_key = api_key
     client = SnapFS(gateway_url=gateway_url, token=token)
     _auto_auth_scanner_client(client, token)

--- a/lib/snapfs/cli.py
+++ b/lib/snapfs/cli.py
@@ -128,25 +128,32 @@ def gateway_options(func: F) -> F:
 
     Commands using this decorator accept:
       --gateway (or env SNAPFS_GATEWAY)
+      --api-key (or env SNAPFS_API_KEY)
       --token   (or env SNAPFS_TOKEN)
 
     Note: options are defined on the *command*, so users can write:
       snapfs scan --gateway https://... /path
     """
     func = click.option(
+        "--api-key",
+        default=None,
+        envvar="SNAPFS_API_KEY",
+        help="API key used to mint a short-lived scanner token for the SnapFS gateway.",
+    )(func)
+    func = click.option(
         "-t",
         "--token",
         default=None,
         envvar="SNAPFS_TOKEN",
-        help="Optional auth token for the SnapFS gateway.",
+        help="Optional auth token for the SnapFS gateway. Advanced use only.",
     )(func)
     func = click.option(
         "-g",
         "--gateway",
         "gateway_url",
-        default=settings.gateway,
+        default=None,
         envvar="SNAPFS_GATEWAY",
-        help=f"SnapFS gateway base URL (default: {settings.gateway}).",
+        help="SnapFS gateway base URL.",
     )(func)
     return func  # type: ignore[return-value]
 
@@ -169,7 +176,7 @@ def cli() -> None:
     """
     SnapFS command line interface (gateway-based).
 
-    Note: This CLI intentionally keeps gateway/token options on each command
+    Note: This CLI intentionally keeps gateway options on each command
     (not global group options) so you can place them after the command.
     """
     pass
@@ -224,6 +231,7 @@ def scan(
     hash_chunk_size: int,
     verbose: int,
     gateway_url: str,
+    api_key: Optional[str],
     token: Optional[str],
 ) -> None:
     """
@@ -236,6 +244,8 @@ def scan(
     """
     _require_gateway(gateway_url)
 
+    if api_key is not None:
+        settings.api_key = api_key
     client = SnapFS(gateway_url=gateway_url, token=token)
     _auto_auth_scanner_client(client, token)
 
@@ -316,6 +326,7 @@ def agent(
     hash_chunk_size: int,
     verbose: int,
     gateway_url: str,
+    api_key: Optional[str],
     token: Optional[str],
 ) -> None:
     """
@@ -327,6 +338,8 @@ def agent(
     """
     _require_gateway(gateway_url)
 
+    if api_key is not None:
+        settings.api_key = api_key
     client = SnapFS(gateway_url=gateway_url, token=token)
     _auto_auth_scanner_client(client, token)
     settings.hash_algo = algo or settings.hash_algo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "snapfs"
-version = "0.4.1"
+version = "0.4.2"
 description = "SnapFS Python client and CLI"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,15 @@ This directory contains helper scripts for local SnapFS workflows.
 
 For benchmark methodology, dataset selection, storage notes, and result interpretation, use [`docs/benchmarks.md`](/mnt/homes/rsg/dev/snapfs/docs/benchmarks.md) as the primary reference.
 
+## `fs_identity_probe.py`
+
+Use `fs_identity_probe.py` to inspect how a filesystem/editor changes inode, link count, and content identity for the same logical path. This is useful when debugging `create` vs `update` behavior across local disks, NFS, and replace-write editor saves.
+
+```bash
+python3 scripts/fs_identity_probe.py /tmp/snapfs-fs-test
+python3 scripts/fs_identity_probe.py /mnt/nfs/share/snapfs-fs-test --pause-for-manual-edit
+```
+
 ## `bench_scan.py`
 
 Benchmark the local scan engine without requiring a real gateway:

--- a/scripts/fs_identity_probe.py
+++ b/scripts/fs_identity_probe.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Probe how a filesystem/editor changes path, inode, nlink, and content identity.
+
+This script creates a small test fixture under a target directory and records
+snapshots after common operations such as hard-linking, in-place writes,
+replace-write saves, and optional manual edits. It is intended to help debug
+how SnapFS should classify create vs update behavior across local disks, NFS,
+and different editors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class EntrySnapshot:
+    path: str
+    exists: bool
+    kind: str
+    inode: Optional[int]
+    dev: Optional[int]
+    nlink: Optional[int]
+    size: Optional[int]
+    mtime_ns: Optional[int]
+    ctime_ns: Optional[int]
+    sha256: Optional[str]
+
+
+@dataclass
+class SnapshotRecord:
+    label: str
+    captured_at: float
+    entries: List[EntrySnapshot]
+    notes: Optional[str] = None
+
+
+FILES = ("A.txt", "B.txt")
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def snapshot_entry(path: Path) -> EntrySnapshot:
+    if not path.exists() and not path.is_symlink():
+        return EntrySnapshot(
+            path=str(path),
+            exists=False,
+            kind="missing",
+            inode=None,
+            dev=None,
+            nlink=None,
+            size=None,
+            mtime_ns=None,
+            ctime_ns=None,
+            sha256=None,
+        )
+
+    st = os.lstat(path)
+    mode = st.st_mode
+    if stat.S_ISDIR(mode):
+        kind = "dir"
+        digest = None
+    elif stat.S_ISLNK(mode):
+        kind = "symlink"
+        digest = None
+    else:
+        kind = "file"
+        digest = sha256_file(path)
+
+    return EntrySnapshot(
+        path=str(path),
+        exists=True,
+        kind=kind,
+        inode=int(getattr(st, "st_ino", 0)) or None,
+        dev=int(getattr(st, "st_dev", 0)) or None,
+        nlink=int(getattr(st, "st_nlink", 0)) or None,
+        size=int(getattr(st, "st_size", 0)) if kind == "file" else None,
+        mtime_ns=int(getattr(st, "st_mtime_ns", 0)) or None,
+        ctime_ns=int(getattr(st, "st_ctime_ns", 0)) or None,
+        sha256=digest,
+    )
+
+
+def capture(
+    label: str, paths: List[Path], notes: Optional[str] = None
+) -> SnapshotRecord:
+    return SnapshotRecord(
+        label=label,
+        captured_at=time.time(),
+        entries=[snapshot_entry(p) for p in paths],
+        notes=notes,
+    )
+
+
+def print_snapshot(record: SnapshotRecord) -> None:
+    print(f"\n== {record.label} ==")
+    if record.notes:
+        print(record.notes)
+    for entry in record.entries:
+        rel = Path(entry.path).name
+        if not entry.exists:
+            print(f"{rel:>8}  missing")
+            continue
+        print(
+            f"{rel:>8}  inode={entry.inode} dev={entry.dev} nlink={entry.nlink} "
+            f"size={entry.size} mtime_ns={entry.mtime_ns} sha256={entry.sha256}"
+        )
+
+
+def write_text(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    os.sync() if hasattr(os, "sync") else None
+
+
+def replace_write(path: Path, text: str) -> None:
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    os.sync() if hasattr(os, "sync") else None
+
+
+def ensure_clean_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def run_probe(target_dir: Path, *, pause_for_manual_edit: bool) -> List[SnapshotRecord]:
+    ensure_clean_dir(target_dir)
+    a = target_dir / "A.txt"
+    b = target_dir / "B.txt"
+
+    write_text(a, "alpha\n")
+    os.link(a, b)
+
+    records = [
+        capture(
+            "baseline_hardlinks",
+            [a, b],
+            notes="A and B should share inode and nlink=2.",
+        )
+    ]
+
+    write_text(a, "alpha\nin-place edit\n")
+    records.append(
+        capture(
+            "after_in_place_write",
+            [a, b],
+            notes="In-place write: many filesystems keep the shared inode.",
+        )
+    )
+
+    # Rebuild baseline before testing replace-write behavior.
+    ensure_clean_dir(target_dir)
+    a = target_dir / "A.txt"
+    b = target_dir / "B.txt"
+    write_text(a, "alpha\n")
+    os.link(a, b)
+    records.append(capture("baseline_before_replace_write", [a, b]))
+
+    replace_write(a, "alpha\nreplace write\n")
+    records.append(
+        capture(
+            "after_replace_write",
+            [a, b],
+            notes="Replace-write often gives A a new inode while B stays on the old inode.",
+        )
+    )
+
+    if pause_for_manual_edit:
+        print(
+            "\nManual edit pause: open A.txt in your editor, save it, then press Enter to continue."
+        )
+        print(f"Target: {a}")
+        input()
+        records.append(
+            capture(
+                "after_manual_editor_save",
+                [a, b],
+                notes="Observed after a manual editor save operation.",
+            )
+        )
+
+    return records
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe filesystem identity behavior for SnapFS lifecycle debugging."
+    )
+    parser.add_argument(
+        "target", help="Directory in which to create the probe fixture."
+    )
+    parser.add_argument(
+        "--pause-for-manual-edit",
+        action="store_true",
+        help="Pause after automated steps so you can save A.txt in an external editor, then capture another snapshot.",
+    )
+    parser.add_argument(
+        "--json-out",
+        help="Optional path to write the full snapshot report as JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    target_dir = Path(args.target).expanduser().resolve()
+    records = run_probe(target_dir, pause_for_manual_edit=args.pause_for_manual_edit)
+
+    print(f"Probe directory: {target_dir}")
+    for record in records:
+        print_snapshot(record)
+
+    if args.json_out:
+        out_path = Path(args.json_out).expanduser().resolve()
+        out_path.write_text(
+            json.dumps([asdict(r) for r in records], indent=2), encoding="utf-8"
+        )
+        print(f"\nWrote JSON report to {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fs_identity_probe.py
+++ b/scripts/fs_identity_probe.py
@@ -146,7 +146,14 @@ def replace_write(path: Path, text: str) -> None:
 
 def ensure_clean_dir(path: Path) -> None:
     if path.exists():
-        shutil.rmtree(path)
+        if not path.is_dir():
+            raise ValueError(f"Target path exists and is not a directory: {path}")
+        if any(path.iterdir()):
+            raise ValueError(
+                f"Refusing to use non-empty target directory: {path}. "
+                "Please provide a new or empty directory."
+            )
+        return
     path.mkdir(parents=True, exist_ok=True)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,100 @@ def test_auto_auth_scanner_client_skips_when_explicit_token(monkeypatch):
     assert client.gateway.exchange_calls == []
 
 
+def test_scan_command_accepts_api_key_option(monkeypatch, tmp_path):
+    """The scan command should accept --api-key and exchange it for a scanner token."""
+    runner = CliRunner()
+    FakeSnapFS.instances.clear()
+    calls = []
+
+    async def fake_scan_dir(
+        path,
+        client,
+        *,
+        force=False,
+        verbose=0,
+        trigger_type="manual",
+        schedule_id=None,
+        algo=None,
+        hash_workers=None,
+        hash_chunk_size=None,
+    ):
+        calls.append({"path": path, "client": client})
+        return {"scan_id": "scan-123"}
+
+    monkeypatch.setattr(cli_module, "SnapFS", FakeSnapFS)
+    monkeypatch.setattr(cli_module.scanner, "scan_dir", fake_scan_dir)
+    monkeypatch.setattr(cli_module.settings, "api_key", None)
+    monkeypatch.setattr(cli_module.settings, "scanner_token_scopes", "ingest:write")
+
+    path = tmp_path / "root"
+    path.mkdir()
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "scan",
+            str(path),
+            "--gateway",
+            "https://tenant.snapfs.com",
+            "--api-key",
+            "sfk_test",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"path": str(path.resolve()), "client": FakeSnapFS.instances[0]}]
+    assert FakeSnapFS.instances[0].gateway.token == "jwt-token"
+    assert FakeSnapFS.instances[0].gateway.exchange_calls == [
+        {"api_key": "sfk_test", "scopes": ["ingest:write"]}
+    ]
+
+
+def test_scan_command_prefers_explicit_token_over_api_key(monkeypatch, tmp_path):
+    """The scan command should not exchange the API key when an explicit token is provided."""
+    runner = CliRunner()
+    FakeSnapFS.instances.clear()
+
+    async def fake_scan_dir(
+        path,
+        client,
+        *,
+        force=False,
+        verbose=0,
+        trigger_type="manual",
+        schedule_id=None,
+        algo=None,
+        hash_workers=None,
+        hash_chunk_size=None,
+    ):
+        return {"scan_id": "scan-123"}
+
+    monkeypatch.setattr(cli_module, "SnapFS", FakeSnapFS)
+    monkeypatch.setattr(cli_module.scanner, "scan_dir", fake_scan_dir)
+    monkeypatch.setattr(cli_module.settings, "api_key", None)
+
+    path = tmp_path / "root"
+    path.mkdir()
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "scan",
+            str(path),
+            "--gateway",
+            "https://tenant.snapfs.com",
+            "--api-key",
+            "sfk_test",
+            "--token",
+            "explicit-token",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert FakeSnapFS.instances[0].gateway.token == "explicit-token"
+    assert FakeSnapFS.instances[0].gateway.exchange_calls == []
+
+
 def test_cli_help_does_not_list_query_command():
     runner = CliRunner()
 
@@ -87,6 +181,29 @@ def test_cli_help_does_not_list_query_command():
     assert " query " not in result.output
     assert "scan" in result.output
     assert "agent" in result.output
+
+
+def test_scan_help_does_not_expose_localhost_gateway_default():
+    runner = CliRunner()
+
+    result = runner.invoke(cli_module.cli, ["scan", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "localhost:8080" not in result.output
+    assert "SnapFS gateway base URL." in result.output
+
+
+def test_scan_command_requires_gateway(monkeypatch, tmp_path):
+    runner = CliRunner()
+    monkeypatch.setattr(cli_module.settings, "api_key", None)
+
+    path = tmp_path / "root"
+    path.mkdir()
+
+    result = runner.invoke(cli_module.cli, ["scan", str(path)])
+
+    assert result.exit_code != 0
+    assert "Missing --gateway (or SNAPFS_GATEWAY)." in result.output
 
 
 def test_scan_command_passes_flags_and_prints_summary(monkeypatch, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,9 @@ def test_scan_help_does_not_expose_localhost_gateway_default():
 def test_scan_command_requires_gateway(monkeypatch, tmp_path):
     runner = CliRunner()
     monkeypatch.setattr(cli_module.settings, "api_key", None)
+    monkeypatch.delenv("SNAPFS_GATEWAY", raising=False)
+    monkeypatch.delenv("SNAPFS_API_KEY", raising=False)
+    monkeypatch.delenv("SNAPFS_TOKEN", raising=False)
 
     path = tmp_path / "root"
     path.mkdir()
@@ -361,6 +364,89 @@ def test_agent_command_passes_values(monkeypatch):
     assert cli_module.settings.hash_algo == "sha1"
     assert cli_module.settings.hash_workers == 1
     assert cli_module.settings.hash_chunk_size == 1048576
+
+
+def test_agent_command_accepts_api_key_option(monkeypatch):
+    """The agent command should accept --api-key and exchange it for a scanner token."""
+    runner = CliRunner()
+    FakeSnapFS.instances.clear()
+    calls = []
+
+    async def fake_run_agent(*, client, agent_id=None, scan_root=None, verbose=0):
+        calls.append(
+            {
+                "client": client,
+                "agent_id": agent_id,
+                "scan_root": scan_root,
+                "verbose": verbose,
+            }
+        )
+
+    monkeypatch.setattr(cli_module, "SnapFS", FakeSnapFS)
+    monkeypatch.setattr(cli_module.agent_mod, "run_agent", fake_run_agent)
+    monkeypatch.setattr(cli_module.settings, "api_key", None)
+    monkeypatch.setattr(cli_module.settings, "scanner_token_scopes", "ingest:write")
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "agent",
+            "--gateway",
+            "https://tenant.snapfs.com",
+            "--api-key",
+            "sfk_test",
+            "--agent-id",
+            "scanner-42",
+            "--root",
+            "/data",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "client": FakeSnapFS.instances[0],
+            "agent_id": "scanner-42",
+            "scan_root": "/data",
+            "verbose": 0,
+        }
+    ]
+    assert FakeSnapFS.instances[0].gateway.token == "jwt-token"
+    assert FakeSnapFS.instances[0].gateway.exchange_calls == [
+        {"api_key": "sfk_test", "scopes": ["ingest:write"]}
+    ]
+
+
+def test_agent_command_prefers_explicit_token_over_api_key(monkeypatch):
+    """The agent command should not exchange the API key when an explicit token is provided."""
+    runner = CliRunner()
+    FakeSnapFS.instances.clear()
+
+    async def fake_run_agent(*, client, agent_id=None, scan_root=None, verbose=0):
+        return None
+
+    monkeypatch.setattr(cli_module, "SnapFS", FakeSnapFS)
+    monkeypatch.setattr(cli_module.agent_mod, "run_agent", fake_run_agent)
+    monkeypatch.setattr(cli_module.settings, "api_key", None)
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "agent",
+            "--gateway",
+            "https://tenant.snapfs.com",
+            "--api-key",
+            "sfk_test",
+            "--token",
+            "explicit-token",
+            "--root",
+            "/data",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert FakeSnapFS.instances[0].gateway.token == "explicit-token"
+    assert FakeSnapFS.instances[0].gateway.exchange_calls == []
 
 
 def test_scan_command_accepts_algo_override(monkeypatch, tmp_path):


### PR DESCRIPTION
This pull request introduces a new first-class `--api-key` CLI option for the `scan` and `agent` commands, improves gateway configuration handling, and adds documentation and tests to support these changes. The update ensures explicit gateway configuration, clarifies authentication flows, and enhances developer tooling for filesystem identity debugging.

**CLI authentication and configuration improvements:**

- Added a new `--api-key` CLI option (and `SNAPFS_API_KEY` env var) to both `scan` and `agent` commands, allowing users to authenticate via API key in addition to bearer tokens. The `--token` option is now marked as advanced use only. Gateway must now be provided explicitly via `--gateway` or `SNAPFS_GATEWAY`; the CLI no longer defaults to localhost. [[1]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532R131-R156) [[2]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532R234) [[3]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532R247-R248) [[4]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532R329) [[5]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532R341-R342) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R30)

- Updated CLI help text and argument handling to reflect these changes, and removed the implicit localhost gateway default from user-facing help. [[1]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532R131-R156) [[2]](diffhunk://#diff-7dd9fd18ddcab8ee94828cd6803de8fdbb6143e715ddc50c2521f578e2623532L172-R179)

**Documentation updates:**

- Added a `.env` example to the `README.md` to illustrate typical gateway, API key, agent ID, and scan root configuration.

- Updated the `CHANGELOG.md` for version 0.4.2 to document these changes.

**Developer tooling and examples:**

- Added a new script, `scripts/fs_identity_probe.py`, and documented it in `scripts/README.md`. This tool helps debug how filesystems and editors affect inode, link count, and content identity—useful for understanding SnapFS create/update behavior. [[1]](diffhunk://#diff-c0d09942dd3a6caca1dd720c2978dd4fd6020cd3a3d3501ce0aeb59886ce07a2R1-R248) [[2]](diffhunk://#diff-25b96aa16f8b9f68c692d0db061713707e9cfc67b296e0ea30908928fb3ffcd6R7-R15)

**Testing improvements:**

- Added tests to verify the new `--api-key` option, preference of explicit tokens over API keys, enforcement of explicit gateway configuration, and correct CLI help output. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR81-R174) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR186-R208)

**Version bump:**

- Bumped version to 0.4.2 in `pyproject.toml` and `lib/snapfs/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-c0f9f6676283274cbfa94aebd20084852097a0b7e662de3e2528d477b3890f87L19-R19)