### PR TITLE
Improve systemd installer yes/no prompt for insecure gateway setting

### DIFF
--- a/systemd/install.sh
+++ b/systemd/install.sh
@@ -254,9 +254,21 @@ prompt_yes_no_value() {
   local reply=""
   local default_prompt="N"
 
-  if [[ "$default" == "1" ]]; then
-    default_prompt="Y"
-  fi
+  default="$(trim "$default")"
+  case "$default" in
+    1|[Yy]|[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn])
+      default="1"
+      default_prompt="Y"
+      ;;
+    0|[Nn]|[Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]|"")
+      default="0"
+      default_prompt="N"
+      ;;
+    *)
+      echo "[ERR] Invalid yes/no default value: $default" >&2
+      exit 1
+      ;;
+  esac
 
   if ! is_interactive; then
     printf '%s' "$default"
@@ -271,6 +283,7 @@ prompt_yes_no_value() {
     reply="${reply:-N}"
   fi
 
+  reply="$(trim "$reply")"
   case "$reply" in
     [Yy]|[Yy][Ee][Ss])
       printf '%s' "1"

--- a/systemd/install.sh
+++ b/systemd/install.sh
@@ -248,6 +248,43 @@ confirm_yes() {
   [[ "$reply" =~ ^[Yy]$ ]]
 }
 
+prompt_yes_no_value() {
+  local prompt="$1"
+  local default="${2:-0}"
+  local reply=""
+  local default_prompt="N"
+
+  if [[ "$default" == "1" ]]; then
+    default_prompt="Y"
+  fi
+
+  if ! is_interactive; then
+    printf '%s' "$default"
+    return 0
+  fi
+
+  if [[ "$default_prompt" == "Y" ]]; then
+    IFS= read -r -p "$prompt [Y/n]: " reply < "${TTY_PATH}"
+    reply="${reply:-Y}"
+  else
+    IFS= read -r -p "$prompt [y/N]: " reply < "${TTY_PATH}"
+    reply="${reply:-N}"
+  fi
+
+  case "$reply" in
+    [Yy]|[Yy][Ee][Ss])
+      printf '%s' "1"
+      ;;
+    [Nn]|[Nn][Oo])
+      printf '%s' "0"
+      ;;
+    *)
+      echo "[ERR] Please answer y or n" >&2
+      exit 1
+      ;;
+  esac
+}
+
 validate_snapfs_bin() {
   local bin="$1"
 
@@ -440,7 +477,7 @@ if [[ "$AS_ROOT" == "0" ]]; then
   fi
 
   SNAPFS_SCANNER_TOKEN_SCOPES_VALUE="$(trim "$(prompt_value 'Scanner token scopes' "$DEFAULT_SCOPES")")"
-  SNAPFS_ALLOW_INSECURE_GATEWAY_VALUE="$(trim "$(prompt_value 'Allow insecure HTTP for remote gateways? (0/1)' "$DEFAULT_ALLOW_INSECURE")")"
+  SNAPFS_ALLOW_INSECURE_GATEWAY_VALUE="$(trim "$(prompt_yes_no_value 'Allow insecure HTTP for remote gateways?' "$DEFAULT_ALLOW_INSECURE")")"
   SNAPFS_AGENT_VERBOSE_VALUE="$(trim "$(prompt_value 'Agent log verbosity (0-2)' "$DEFAULT_AGENT_VERBOSE")")"
   SNAPFS_HASH_ALGO_VALUE="$(trim "$(prompt_hash_algorithm "$DEFAULT_HASH_ALGO" "$SNAPFS_BIN_VALUE")")"
   if [[ -z "$SNAPFS_HASH_ALGO_VALUE" ]]; then


### PR DESCRIPTION
This pull request introduces a new helper function to improve how yes/no prompts are handled in the `systemd/install.sh` script. The main enhancement is the addition of the `prompt_yes_no_value` function, which standardizes yes/no user input and default handling, and its integration into the configuration flow.

User input improvements:

* Added a new `prompt_yes_no_value` function to handle yes/no prompts with default values, better input validation, and support for non-interactive environments.
* Updated the prompt for "Allow insecure HTTP for remote gateways?" to use the new `prompt_yes_no_value` function, ensuring consistent and clearer user interaction.